### PR TITLE
`domain`: adds solutions graphql query.

### DIFF
--- a/domain/gql/fields/fields.go
+++ b/domain/gql/fields/fields.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chris-ramon/golang-scaffolding/domain/auth/mappers"
 	"github.com/chris-ramon/golang-scaffolding/domain/gql/types"
+	solutionsMappers "github.com/chris-ramon/golang-scaffolding/domain/solutions/mappers"
 	usersMappers "github.com/chris-ramon/golang-scaffolding/domain/users/mappers"
 	"github.com/chris-ramon/golang-scaffolding/pkg/ctxutil"
 )
@@ -102,6 +103,18 @@ var SolutionsField = &graphql.Field{
 	Name: "Solutions",
 	Type: graphql.NewList(types.SolutionType),
 	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-		return nil, nil
+		srvs, err := servicesFromResolveParams(p)
+		if err != nil {
+			return nil, err
+		}
+
+		solutions, err := srvs.SolutionService.FindAnalysis(p.Context)
+		if err != nil {
+			return nil, err
+		}
+
+		solutionsAPI := solutionsMappers.SolutionsFromTypeToAPI(solutions)
+
+		return solutionsAPI, nil
 	},
 }

--- a/domain/gql/fields/fields.go
+++ b/domain/gql/fields/fields.go
@@ -97,3 +97,11 @@ var UsersField = &graphql.Field{
 		return usersAPI, nil
 	},
 }
+
+var SolutionsField = &graphql.Field{
+	Name: "Solutions",
+	Type: graphql.NewList(types.SolutionType),
+	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		return nil, nil
+	},
+}

--- a/domain/gql/handler.go
+++ b/domain/gql/handler.go
@@ -22,7 +22,7 @@ func (h *handlers) GetGraphQL() *handler.Handler {
 	return h.gqlHandler
 }
 
-func NewHandlers(authService services.AuthService, userService services.UserService) (*handlers, error) {
+func NewHandlers(authService services.AuthService, userService services.UserService, solutionService services.SolutionService) (*handlers, error) {
 	appSchema, err := schema.New()
 	if err != nil {
 		return nil, err
@@ -31,8 +31,9 @@ func NewHandlers(authService services.AuthService, userService services.UserServ
 	rootObjectFn := func(ctx context.Context, r *http.Request) map[string]interface{} {
 		rootObject := map[string]interface{}{
 			"services": &services.Services{
-				AuthService: authService,
-				UserService: userService,
+				AuthService:     authService,
+				UserService:     userService,
+				SolutionService: solutionService,
 			},
 		}
 		return rootObject

--- a/domain/gql/operations/operations.go
+++ b/domain/gql/operations/operations.go
@@ -12,6 +12,7 @@ var Query = graphql.NewObject(graphql.ObjectConfig{
 		"ping":        fields.PingField,
 		"currentUser": fields.CurrentUserField,
 		"users":       fields.UsersField,
+		"solutions":   fields.SolutionsField,
 	},
 })
 

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -50,7 +50,7 @@ var AnalysisType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "AnalysisType",
 	Fields: graphql.Fields{
 		"information": &graphql.Field{
-			Description: "The analysis list of the solution.",
+			Description: "The information list of the solution.",
 			Type:        graphql.NewList(InformationType),
 		},
 	},

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -80,7 +80,7 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "MetricsType",
 	Fields: graphql.Fields{
 		"pullRequests": &graphql.Field{
-			Description: "The metrics of pull requests.",
+			Description: "The list of pull requests.",
 			Type:        graphql.NewList(PullRequestType),
 		},
 	},

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -35,3 +35,77 @@ var UserType = graphql.NewObject(graphql.ObjectConfig{
 		},
 	},
 })
+
+var SolutionType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "SolutionType",
+	Fields: graphql.Fields{
+		"analysis": &graphql.Field{
+			Description: "The analysis list of the solution.",
+			Type:        graphql.NewList(AnalysisType),
+		},
+	},
+})
+
+var AnalysisType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "AnalysisType",
+	Fields: graphql.Fields{
+		"information": &graphql.Field{
+			Description: "The analysis list of the solution.",
+			Type:        graphql.NewList(InformationType),
+		},
+	},
+})
+
+var InformationType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "InformationType",
+	Fields: graphql.Fields{
+		"github": &graphql.Field{
+			Description: "The GitHub information.",
+			Type:        GitHubType,
+		},
+	},
+})
+
+var GitHubType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "GitHubType",
+	Fields: graphql.Fields{
+		"metrics": &graphql.Field{
+			Description: "The GitHub metrics.",
+			Type:        MetricsType,
+		},
+	},
+})
+
+var MetricsType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "MetricsType",
+	Fields: graphql.Fields{
+		"pullRequests": &graphql.Field{
+			Description: "The metrics of pull requests.",
+			Type:        graphql.NewList(PullRequestType),
+		},
+	},
+})
+
+var PullRequestType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "PullRequestType",
+	Fields: graphql.Fields{
+		"duration": &graphql.Field{
+			Description: "The duration of the pull request.",
+			Type:        graphql.Int,
+		},
+		"contributors": &graphql.Field{
+			Description: "The contributors of the pull request.",
+			Type:        graphql.NewList(ContributorType),
+		},
+	},
+})
+
+var ContributorType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "ContributorType",
+	Fields: graphql.Fields{
+		"profileUrl": &graphql.Field{
+			Description: "The profile url of a contributor.",
+			Type:        graphql.String,
+		},
+	},
+})

--- a/domain/internal/services/services.go
+++ b/domain/internal/services/services.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	authTypes "github.com/chris-ramon/golang-scaffolding/domain/auth/types"
+	solutionTypes "github.com/chris-ramon/golang-scaffolding/domain/solutions/types"
 	userTypes "github.com/chris-ramon/golang-scaffolding/domain/users/types"
 )
 
@@ -15,7 +16,12 @@ type UserService interface {
 	FindUsers(ctx context.Context) ([]*userTypes.User, error)
 }
 
+type SolutionService interface {
+	FindAnalysis(ctx context.Context) ([]*solutionTypes.Solution, error)
+}
+
 type Services struct {
-	AuthService AuthService
-	UserService UserService
+	AuthService     AuthService
+	UserService     UserService
+	SolutionService SolutionService
 }

--- a/domain/solutions/api/api.go
+++ b/domain/solutions/api/api.go
@@ -1,0 +1,4 @@
+package api
+
+type Solution struct {
+}

--- a/domain/solutions/mappers/mappers.go
+++ b/domain/solutions/mappers/mappers.go
@@ -1,0 +1,16 @@
+package mappers
+
+import (
+	"github.com/chris-ramon/golang-scaffolding/domain/solutions/api"
+	"github.com/chris-ramon/golang-scaffolding/domain/solutions/types"
+)
+
+func SolutionsFromTypeToAPI(solutions []*types.Solution) []api.Solution {
+	result := []api.Solution{}
+
+	// for _, solution := range solutions {
+	// 	result = append(result, api.Solution{})
+	// }
+
+	return result
+}

--- a/domain/solutions/service.go
+++ b/domain/solutions/service.go
@@ -1,0 +1,20 @@
+package solutions
+
+import (
+	"context"
+
+	"github.com/chris-ramon/golang-scaffolding/domain/solutions/types"
+)
+
+type service struct {
+}
+
+func (s *service) FindAnalysis(ctx context.Context) ([]*types.Solution, error) {
+	result := []*types.Solution{}
+
+	return result, nil
+}
+
+func NewService() (*service, error) {
+	return &service{}, nil
+}

--- a/domain/solutions/types/types.go
+++ b/domain/solutions/types/types.go
@@ -1,0 +1,4 @@
+package types
+
+type Solution struct {
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chris-ramon/golang-scaffolding/domain/admin"
 	"github.com/chris-ramon/golang-scaffolding/domain/auth"
 	"github.com/chris-ramon/golang-scaffolding/domain/gql"
+	"github.com/chris-ramon/golang-scaffolding/domain/solutions"
 	"github.com/chris-ramon/golang-scaffolding/domain/users"
 	"github.com/chris-ramon/golang-scaffolding/pkg/jwt"
 )
@@ -56,7 +57,12 @@ func main() {
 	authHandlers := auth.NewHandlers(authService)
 	authRoutes := auth.NewRoutes(authHandlers)
 
-	gqlHandlers, err := gql.NewHandlers(authService, usersService)
+	solutionService, err := solutions.NewService()
+	if err != nil {
+		handleErr(err)
+	}
+
+	gqlHandlers, err := gql.NewHandlers(authService, usersService, solutionService)
 	if err != nil {
 		handleErr(err)
 	}


### PR DESCRIPTION
#### Details
- `main`: wires solutions pkg service & gql.
- `domain/gql`: adds SolutionsField resolve implementation.
- `domain/gql`: wires SolutionService.
- `domain/internal`: adds SolutionService interface.
- `domain/solutions`: adds initial scaffolding.
- `domain`: adds solutions related types down to pull requests.
- Related issue: https://github.com/chris-ramon/design-doc-self-generator/issues/1.

#### Test Plan
- :heavy_check_mark:  Tested that the `solutions` query works as expected:

![Screenshot from 2025-04-21 16-53-09](https://github.com/user-attachments/assets/c3bae2e9-26ea-49a2-b5a2-3808b3e699ef)
