### PR TITLE
domain: adds `solutions` query sub-fields arguments `pullRequests` and `contributors`.

### DIFF
--- a/domain/gql/fields/fields.go
+++ b/domain/gql/fields/fields.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chris-ramon/golang-scaffolding/domain/auth/mappers"
 	"github.com/chris-ramon/golang-scaffolding/domain/gql/types"
+	"github.com/chris-ramon/golang-scaffolding/domain/gql/util"
 	solutionsMappers "github.com/chris-ramon/golang-scaffolding/domain/solutions/mappers"
 	usersMappers "github.com/chris-ramon/golang-scaffolding/domain/users/mappers"
 	"github.com/chris-ramon/golang-scaffolding/pkg/ctxutil"
@@ -22,7 +23,7 @@ var CurrentUserField = &graphql.Field{
 	Name: "CurrentUser",
 	Type: types.CurrentUserType,
 	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-		srvs, err := servicesFromResolveParams(p)
+		srvs, err := util.ServicesFromResolveParams(p)
 		if err != nil {
 			return nil, err
 		}
@@ -55,17 +56,17 @@ var AuthUserField = &graphql.Field{
 		},
 	},
 	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-		srvs, err := servicesFromResolveParams(p)
+		srvs, err := util.ServicesFromResolveParams(p)
 		if err != nil {
 			return nil, err
 		}
 
-		username, err := fieldFromArgs[string](p.Args, "username")
+		username, err := util.FieldFromArgs[string](p.Args, "username")
 		if err != nil {
 			return nil, err
 		}
 
-		password, err := fieldFromArgs[string](p.Args, "password")
+		password, err := util.FieldFromArgs[string](p.Args, "password")
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +84,7 @@ var UsersField = &graphql.Field{
 	Name: "Users",
 	Type: graphql.NewList(types.UserType),
 	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-		srvs, err := servicesFromResolveParams(p)
+		srvs, err := util.ServicesFromResolveParams(p)
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +104,7 @@ var SolutionsField = &graphql.Field{
 	Name: "Solutions",
 	Type: graphql.NewList(types.SolutionType),
 	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-		srvs, err := servicesFromResolveParams(p)
+		srvs, err := util.ServicesFromResolveParams(p)
 		if err != nil {
 			return nil, err
 		}

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -1,7 +1,11 @@
 package types
 
 import (
+	"log"
+
 	"github.com/graphql-go/graphql"
+
+	"github.com/chris-ramon/golang-scaffolding/domain/gql/util"
 )
 
 var CurrentUserType = graphql.NewObject(graphql.ObjectConfig{
@@ -82,6 +86,22 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 		"pullRequests": &graphql.Field{
 			Description: "The list of pull requests.",
 			Type:        graphql.NewList(PullRequestType),
+			Args: graphql.FieldConfigArgument{
+				"ids": &graphql.ArgumentConfig{
+					// Type: graphql.NewList(graphql.Int),
+					Type: graphql.Int,
+				},
+			},
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				ids, err := util.FieldFromArgs[int](p.Args, "ids")
+				if err != nil {
+					return nil, err
+				}
+
+				log.Printf("ids: %+v", ids)
+
+				return nil, nil
+			},
 		},
 	},
 })

--- a/domain/gql/util/util.go
+++ b/domain/gql/util/util.go
@@ -1,4 +1,4 @@
-package fields
+package util
 
 import (
 	"errors"
@@ -8,7 +8,7 @@ import (
 	"github.com/chris-ramon/golang-scaffolding/domain/internal/services"
 )
 
-func servicesFromResolveParams(p graphql.ResolveParams) (*services.Services, error) {
+func ServicesFromResolveParams(p graphql.ResolveParams) (*services.Services, error) {
 	rootValue := p.Info.RootValue.(map[string]interface{})
 	srvs, ok := rootValue["services"].(*services.Services)
 
@@ -19,7 +19,7 @@ func servicesFromResolveParams(p graphql.ResolveParams) (*services.Services, err
 	return srvs, nil
 }
 
-func fieldFromArgs[T any](args map[string]interface{}, fieldName string) (T, error) {
+func FieldFromArgs[T any](args map[string]interface{}, fieldName string) (T, error) {
 	field, ok := args[fieldName].(T)
 
 	if !ok {


### PR DESCRIPTION
#### Details
- `domain/gql`: syncs util pkg importing path.
- `domain/gql`: adds args and resolve fields to pullRequests type.
- `domain/gql`: consolidates util functions into its own pkg.


#### Test Plan
- :heavy_check_mark:  Tested that `solutions` query sub-fields arguments: `pullRequests` works as expected:

![Screenshot from 2025-04-24 16-52-15](https://github.com/user-attachments/assets/9ac8b687-681c-4b05-8f10-9806fc76bd07)
