### PR TITLE
{domain,go.mod}: adds `pullRequests` type implementation.

### DIFF
--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/chris-ramon/golang-scaffolding/domain/gql/util"
-	// metricsTypes "github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
+	metrics "github.com/chris-ramon/golang-scaffolding/domain/metrics"
 )
 
 var CurrentUserType = graphql.NewObject(graphql.ObjectConfig{
@@ -103,10 +103,10 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 				}
 
 				log.Println(ids)
-				// params := metricsTypes.FindPullRequestsParams{
-				//   IDs: ids,
-				// }
-				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context)
+				params := metrics.FindPullRequestsParams{
+					IDs: ids,
+				}
+				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context, params)
 				if err != nil {
 					return nil, err
 				}

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -113,7 +113,9 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 					return nil, err
 				}
 
-				return findPullRequestsResult.PullRequests, nil
+				pullRequests := mappers.PullRequestsFromTypeToAPI(findPullRequestsResult.PullRequests)
+
+				return pullRequests, nil
 			},
 		},
 	},

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"github.com/graphql-go/graphql"
-	"log"
 
 	"github.com/chris-ramon/golang-scaffolding/domain/gql/util"
 	"github.com/chris-ramon/golang-scaffolding/domain/metrics/github"
@@ -109,14 +108,12 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 				}
 				params := mappers.PullRequestsFromTypeToFindParam(prs)
 
-				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context, params)
+				findPullRequestsResult, err := srvs.MetricsService.FindPullRequests(p.Context, params)
 				if err != nil {
 					return nil, err
 				}
 
-				log.Println(pullRequests)
-
-				return []string{pullRequests}, nil
+				return findPullRequestsResult.PullRequests, nil
 			},
 		},
 	},

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/chris-ramon/golang-scaffolding/domain/gql/util"
-	metrics "github.com/chris-ramon/golang-scaffolding/domain/metrics"
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics/github"
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics/mappers"
 )
 
 var CurrentUserType = graphql.NewObject(graphql.ObjectConfig{
@@ -102,12 +103,12 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 					return nil, err
 				}
 
-				params := metrics.FindPullRequestsParams{
-					URLs:   urls,
-					Owner:  "",
-					Repo:   "",
-					Number: 1,
+				prs, err := github.PullRequestsFromURLs(urls)
+				if err != nil {
+					return nil, err
 				}
+				params := mappers.PullRequestsFromTypeToFindParam(prs)
+
 				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context, params)
 				if err != nil {
 					return nil, err

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/chris-ramon/golang-scaffolding/domain/gql/util"
+	// metricsTypes "github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
 )
 
 var CurrentUserType = graphql.NewObject(graphql.ObjectConfig{
@@ -101,7 +102,11 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 					return nil, err
 				}
 
-				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context, ids)
+				log.Println(ids)
+				// params := metricsTypes.FindPullRequestsParams{
+				//   IDs: ids,
+				// }
+				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context)
 				if err != nil {
 					return nil, err
 				}

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -87,12 +87,12 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 			Description: "The list of pull requests.",
 			Type:        graphql.NewList(PullRequestType),
 			Args: graphql.FieldConfigArgument{
-				"ids": &graphql.ArgumentConfig{
-					Type: graphql.NewList(graphql.Int),
+				"urls": &graphql.ArgumentConfig{
+					Type: graphql.NewList(graphql.String),
 				},
 			},
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-				ids, err := util.FieldsFromArgs[int](p.Args, "ids")
+				urls, err := util.FieldsFromArgs[string](p.Args, "urls")
 				if err != nil {
 					return nil, err
 				}
@@ -102,9 +102,11 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 					return nil, err
 				}
 
-				log.Println(ids)
 				params := metrics.FindPullRequestsParams{
-					IDs: ids,
+					URLs:   urls,
+					Owner:  "",
+					Repo:   "",
+					Number: 1,
 				}
 				pullRequests, err := srvs.MetricsService.FindPullRequests(p.Context, params)
 				if err != nil {

--- a/domain/internal/services/services.go
+++ b/domain/internal/services/services.go
@@ -3,7 +3,7 @@ package services
 import (
 	"context"
 	authTypes "github.com/chris-ramon/golang-scaffolding/domain/auth/types"
-	metrics "github.com/chris-ramon/golang-scaffolding/domain/metrics"
+	metricTypes "github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
 	solutionTypes "github.com/chris-ramon/golang-scaffolding/domain/solutions/types"
 	userTypes "github.com/chris-ramon/golang-scaffolding/domain/users/types"
 )
@@ -22,7 +22,7 @@ type SolutionService interface {
 }
 
 type MetricsService interface {
-	FindPullRequests(ctx context.Context, params metrics.FindPullRequestsParams) (string, error)
+	FindPullRequests(ctx context.Context, params metricTypes.FindPullRequestsParams) (string, error)
 }
 
 type Services struct {

--- a/domain/internal/services/services.go
+++ b/domain/internal/services/services.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	authTypes "github.com/chris-ramon/golang-scaffolding/domain/auth/types"
+	metrics "github.com/chris-ramon/golang-scaffolding/domain/metrics"
 	solutionTypes "github.com/chris-ramon/golang-scaffolding/domain/solutions/types"
 	userTypes "github.com/chris-ramon/golang-scaffolding/domain/users/types"
 )
@@ -21,7 +22,7 @@ type SolutionService interface {
 }
 
 type MetricsService interface {
-	FindPullRequests(ctx context.Context) (string, error)
+	FindPullRequests(ctx context.Context, params metrics.FindPullRequestsParams) (string, error)
 }
 
 type Services struct {

--- a/domain/internal/services/services.go
+++ b/domain/internal/services/services.go
@@ -21,7 +21,7 @@ type SolutionService interface {
 }
 
 type MetricsService interface {
-	FindPullRequests(ctx context.Context, ids []int) (string, error)
+	FindPullRequests(ctx context.Context) (string, error)
 }
 
 type Services struct {

--- a/domain/internal/services/services.go
+++ b/domain/internal/services/services.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	authTypes "github.com/chris-ramon/golang-scaffolding/domain/auth/types"
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics"
 	metricTypes "github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
 	solutionTypes "github.com/chris-ramon/golang-scaffolding/domain/solutions/types"
 	userTypes "github.com/chris-ramon/golang-scaffolding/domain/users/types"
@@ -22,7 +23,7 @@ type SolutionService interface {
 }
 
 type MetricsService interface {
-	FindPullRequests(ctx context.Context, params metricTypes.FindPullRequestsParams) (string, error)
+	FindPullRequests(ctx context.Context, params metricTypes.FindPullRequestsParams) (*metrics.FindPullRequestsResult, error)
 }
 
 type Services struct {

--- a/domain/metrics/api/api.go
+++ b/domain/metrics/api/api.go
@@ -1,0 +1,10 @@
+package api
+
+// PullRequest represents a pull request.
+type PullRequest struct {
+	// Duration is the duration time of the pull request.
+	Duration float64 `json:"duration"`
+}
+
+// PullRequests are a slice of pull requests.
+type PullRequests []PullRequest

--- a/domain/metrics/github/urls.go
+++ b/domain/metrics/github/urls.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
+)
+
+// PullRequestsFromURLs returns a slice of pull requests from given pull requests URLs.
+func PullRequestsFromURLs(urls []string) (types.PullRequests, error) {
+	result := types.PullRequests{}
+
+	for _, url := range urls {
+		pr, err := PullRequestFromURL(url)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, *pr)
+	}
+
+	return result, nil
+}
+
+// PullRequestFromURL returns a pull request type from given pull request URL.
+func PullRequestFromURL(url string) (*types.PullRequest, error) {
+	parts := strings.Split(url, "/")
+	if len(parts) == 0 {
+		return nil, errors.New("failed to split url parts")
+	}
+
+	owner := parts[3]
+	repo := parts[4]
+
+	number, err := strconv.Atoi(parts[6])
+	if err != nil {
+		return nil, err
+	}
+
+	result := &types.PullRequest{
+		Owner:  owner,
+		Repo:   repo,
+		Number: number,
+	}
+
+	return result, nil
+}

--- a/domain/metrics/mappers/mappers.go
+++ b/domain/metrics/mappers/mappers.go
@@ -1,0 +1,28 @@
+package mappers
+
+import (
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
+)
+
+// PullRequestsFromTypeToFindParam maps given pull requests internal types to pull request find types.
+func PullRequestsFromTypeToFindParam(pullRequests types.PullRequests) types.FindPullRequestsParams {
+	result := types.FindPullRequestsParams{}
+
+	for _, pr := range pullRequests {
+		pullRequest := PullRequestFromTypeToFindParam(pr)
+		result = append(result, pullRequest)
+	}
+
+	return result
+}
+
+// PullRequestFromTypeToFindParam maps given pull request internal type to pull request find type.
+func PullRequestFromTypeToFindParam(pullRequest types.PullRequest) types.FindPullRequestParam {
+	result := types.FindPullRequestParam{
+		Number: pullRequest.Number,
+		Owner:  pullRequest.Owner,
+		Repo:   pullRequest.Repo,
+	}
+
+	return result
+}

--- a/domain/metrics/mappers/mappers.go
+++ b/domain/metrics/mappers/mappers.go
@@ -1,6 +1,7 @@
 package mappers
 
 import (
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics/api"
 	"github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
 )
 
@@ -25,4 +26,23 @@ func PullRequestFromTypeToFindParam(pullRequest types.PullRequest) types.FindPul
 	}
 
 	return result
+}
+
+// PullRequestsFromTypeToAPI maps given pull requests internal types to pull requests API types.
+func PullRequestsFromTypeToAPI(pullRequests []*types.PullRequest) api.PullRequests {
+	result := api.PullRequests{}
+
+	for _, pullRequest := range pullRequests {
+		pr := PullRequestFromTypeToAPI(pullRequest)
+		result = append(result, pr)
+	}
+
+	return result
+}
+
+// PullRequestFromTypeToAPI maps given pull request internal type to pull request API type.
+func PullRequestFromTypeToAPI(pullRequest *types.PullRequest) api.PullRequest {
+	return api.PullRequest{
+		Duration: pullRequest.Duration.Hours() / 24,
+	}
 }

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -2,12 +2,54 @@ package metrics
 
 import (
 	"context"
+	"log"
+	"net/http"
+
+	"github.com/google/go-github/github"
 )
 
 type service struct {
 }
 
-func (s *service) FindPullRequests(ctx context.Context, ids []int) (string, error) {
+type FindPullRequestsParams struct {
+	IDs    []int
+	Owner  string
+	Repo   string
+	Number int
+
+	// HTTPClient is the HTTP client used for GitHub API requests.
+	HTTPClient *http.Client
+}
+
+type FindPullRequestsResult struct {
+	PullRequest *PullRequest
+}
+
+func (s *service) FindPullRequests(ctx context.Context) (string, error) {
+	p := FindPullRequestsParams{}
+
+	// Create a GitHub client using the provided HTTP client.
+	client := github.NewClient(p.HTTPClient)
+
+	// Fetch pull request information from GitHub.
+	pullRequest, _, err := client.PullRequests.Get(ctx, p.Owner, p.Repo, p.Number)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract pull request metrics.
+	duration := pullRequest.CreatedAt.Sub(*pullRequest.MergedAt)
+	pr := &PullRequest{
+		Duration: duration,
+	}
+
+	// Create the result.
+	result := &FindPullRequestsResult{
+		PullRequest: pr,
+	}
+
+	log.Printf("result: %+v", result)
+
 	return "ok", nil
 }
 

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	"github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
@@ -15,42 +14,50 @@ type service struct {
 }
 
 type FindPullRequestsResult struct {
+	PullRequests []*types.PullRequest
+}
+
+type findPullRequestsResult struct {
 	PullRequest *types.PullRequest
 }
 
-func (s *service) FindPullRequests(ctx context.Context, params types.FindPullRequestsParams) (string, error) {
+func (s *service) FindPullRequests(ctx context.Context, params types.FindPullRequestsParams) (*FindPullRequestsResult, error) {
+	result := &FindPullRequestsResult{}
+
 	for _, pr := range params {
-		s.findPullRequests(ctx, pr)
+		r, err := s.findPullRequests(ctx, pr)
+		if err != nil {
+			return nil, err
+		}
+
+		result.PullRequests = append(result.PullRequests, r.PullRequest)
 	}
 
-	return "ok", nil
+	return result, nil
 }
 
-func (s *service) findPullRequests(ctx context.Context, param types.FindPullRequestParam) (string, error) {
+func (s *service) findPullRequests(ctx context.Context, param types.FindPullRequestParam) (*findPullRequestsResult, error) {
 	// Create a GitHub client using the provided HTTP client.
 	client := github.NewClient(s.HTTPClient)
 
 	// Fetch pull request information from GitHub.
 	pullRequest, _, err := client.PullRequests.Get(ctx, param.Owner, param.Repo, param.Number)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Extract pull request metrics.
-	duration := pullRequest.CreatedAt.Sub(*pullRequest.MergedAt)
+	duration := pullRequest.MergedAt.Sub(*pullRequest.CreatedAt)
 	pr := &types.PullRequest{
 		Duration: duration,
 	}
 
 	// Create the result.
-	result := &FindPullRequestsResult{
+	result := &findPullRequestsResult{
 		PullRequest: pr,
 	}
 
-	log.Printf("result: %+v", result)
-
-	return "ok", nil
-
+	return result, nil
 }
 
 func NewService(HTTPClient *http.Client) (*service, error) {

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
 	"github.com/google/go-github/github"
 )
 
@@ -22,24 +23,22 @@ type FindPullRequestsParams struct {
 }
 
 type FindPullRequestsResult struct {
-	PullRequest *PullRequest
+	PullRequest *types.PullRequest
 }
 
-func (s *service) FindPullRequests(ctx context.Context) (string, error) {
-	p := FindPullRequestsParams{}
-
+func (s *service) FindPullRequests(ctx context.Context, params FindPullRequestsParams) (string, error) {
 	// Create a GitHub client using the provided HTTP client.
-	client := github.NewClient(p.HTTPClient)
+	client := github.NewClient(params.HTTPClient)
 
 	// Fetch pull request information from GitHub.
-	pullRequest, _, err := client.PullRequests.Get(ctx, p.Owner, p.Repo, p.Number)
+	pullRequest, _, err := client.PullRequests.Get(ctx, params.Owner, params.Repo, params.Number)
 	if err != nil {
 		return "", err
 	}
 
 	// Extract pull request metrics.
 	duration := pullRequest.CreatedAt.Sub(*pullRequest.MergedAt)
-	pr := &PullRequest{
+	pr := &types.PullRequest{
 		Duration: duration,
 	}
 

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -10,14 +10,6 @@ import (
 )
 
 type service struct {
-}
-
-type FindPullRequestsParams struct {
-	IDs    []int
-	Owner  string
-	Repo   string
-	Number int
-
 	// HTTPClient is the HTTP client used for GitHub API requests.
 	HTTPClient *http.Client
 }
@@ -26,12 +18,20 @@ type FindPullRequestsResult struct {
 	PullRequest *types.PullRequest
 }
 
-func (s *service) FindPullRequests(ctx context.Context, params FindPullRequestsParams) (string, error) {
+func (s *service) FindPullRequests(ctx context.Context, params types.FindPullRequestsParams) (string, error) {
+	for _, pr := range params {
+		s.findPullRequests(ctx, pr)
+	}
+
+	return "ok", nil
+}
+
+func (s *service) findPullRequests(ctx context.Context, param types.FindPullRequestParam) (string, error) {
 	// Create a GitHub client using the provided HTTP client.
-	client := github.NewClient(params.HTTPClient)
+	client := github.NewClient(s.HTTPClient)
 
 	// Fetch pull request information from GitHub.
-	pullRequest, _, err := client.PullRequests.Get(ctx, params.Owner, params.Repo, params.Number)
+	pullRequest, _, err := client.PullRequests.Get(ctx, param.Owner, param.Repo, param.Number)
 	if err != nil {
 		return "", err
 	}
@@ -50,8 +50,9 @@ func (s *service) FindPullRequests(ctx context.Context, params FindPullRequestsP
 	log.Printf("result: %+v", result)
 
 	return "ok", nil
+
 }
 
-func NewService() (*service, error) {
-	return &service{}, nil
+func NewService(HTTPClient *http.Client) (*service, error) {
+	return &service{HTTPClient: HTTPClient}, nil
 }

--- a/domain/metrics/types.go
+++ b/domain/metrics/types.go
@@ -1,0 +1,7 @@
+package metrics
+
+import "time"
+
+type PullRequest struct {
+	Duration time.Duration
+}

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -2,6 +2,35 @@ package types
 
 import "time"
 
+// PullRequest represents an internal pull request.
 type PullRequest struct {
+	// Duration is the duration time of the pull request.
 	Duration time.Duration
+
+	// Number is the unique number of the pull request.
+	Number int
+
+	// Owner is the owner of the pull request.
+	Owner string
+
+	// Repo is the repository name of the pull request.
+	Repo string
 }
+
+// PullRequests are a slice of pull requests.
+type PullRequests []PullRequest
+
+// FindPullRequestParam represents the find parameters.
+type FindPullRequestParam struct {
+	// Number is the unique number parameter.
+	Number int
+
+	// Owner is the owner parameter.
+	Owner string
+
+	// Repo is the repository name parameter.
+	Repo string
+}
+
+// FindPullRequestsParams are a slice of find pull requests parameters.
+type FindPullRequestsParams []FindPullRequestParam

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -1,4 +1,4 @@
-package metrics
+package types
 
 import "time"
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 
 require (
 	github.com/evanw/esbuild v0.12.17 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,11 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/main.go
+++ b/main.go
@@ -63,7 +63,8 @@ func main() {
 		handleErr(err)
 	}
 
-	metricsService, err := metrics.NewService()
+	HTTPClient := &http.Client{}
+	metricsService, err := metrics.NewService(HTTPClient)
 	if err != nil {
 		handleErr(err)
 	}


### PR DESCRIPTION
#### Details
- `domain/gql`: wires PullRequestsFromTypeToAPI mapper.
- `domain/metrics`: adds PullRequestsFromTypeToAPI & PullRequestFromTypeToAPI mappers.
- `domain/metrics`: adds PullRequest & PullRequests types.
- `domain/gql`: wires MetricsService.FindPullRequests result.
- `domain`: syncs metrics.FindPullRequests method.
- `main`: wires metrics.NewService params.
- `domain/gql`: consolidates MetricsService.FindPullRequests method params.
- `domain/metrics`: consolidates NewService method and syncs pkg types.
- `domain/internal`: syncs MetricsService interface.
- `domain/metrics`: adds PullRequests & FindPullRequestParam types.
- `domain/metrics`: adds github pkg.
- `domain/metrics`: adds mappers pkg.
- `gql/types`: adds MetricsType urls field.
- `internal/services`: syncs MetricsService.FindPullRequests method.
- `gql/types`: wires metrics.FindPullRequestsParams.
- `metrics/service`: wires FindPullRequestsParams.
- `metrics/types`: adds types pkg.
- `domain/gql`: syncs MetricsType.
- `domain/metrics`: adds service FindPullRequests function implementation.
- `domain/internal`: updates MetricsService.FindPullRequests definition.
- `domain/metrics`: adds metrics types file.
- `go.mod`: adds github.com/google/go-github pkg.


#### Test Plan
- :heavy_check_mark:  Tested that `pullRequests` type works as expected, only implemented the duration field:

![Screenshot from 2025-04-30 15-30-38](https://github.com/user-attachments/assets/2028334a-9d12-4e7f-9924-633898d9ae91)
