### PR TITLE
domain: adds `pullRequest.Duration` type.

### DIFF
--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -124,13 +124,27 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 var PullRequestType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "PullRequestType",
 	Fields: graphql.Fields{
-		"durationInDays": &graphql.Field{
-			Description: "The duration of the pull request in days.",
-			Type:        graphql.Int,
+		"duration": &graphql.Field{
+			Description: "The duration of the pull request.",
+			Type:        DurationType,
 		},
 		"contributors": &graphql.Field{
 			Description: "The contributors of the pull request.",
 			Type:        graphql.NewList(ContributorType),
+		},
+	},
+})
+
+var DurationType = graphql.NewObject(graphql.ObjectConfig{
+	Name: "DurationType",
+	Fields: graphql.Fields{
+		"inDays": &graphql.Field{
+			Description: "The time duration in days.",
+			Type:        graphql.Int,
+		},
+		"formattedIntervalDates": &graphql.Field{
+			Description: "The time formatted interval dates.",
+			Type:        graphql.String,
 		},
 	},
 })

--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -124,8 +124,8 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 var PullRequestType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "PullRequestType",
 	Fields: graphql.Fields{
-		"duration": &graphql.Field{
-			Description: "The duration of the pull request.",
+		"durationInDays": &graphql.Field{
+			Description: "The duration of the pull request in days.",
 			Type:        graphql.Int,
 		},
 		"contributors": &graphql.Field{

--- a/domain/metrics/api/api.go
+++ b/domain/metrics/api/api.go
@@ -1,9 +1,28 @@
 package api
 
+import (
+	"time"
+)
+
 // PullRequest represents a pull request.
 type PullRequest struct {
-	// DurationInDays is the duration time of the pull request in days.
-	DurationInDays float64 `json:"durationInDays"`
+	// Duration is the duration time of the pull request.
+	Duration Duration
+
+	// CreatedAt is the pull request created at time.
+	CreatedAt *time.Time
+
+	// MergedAt is the pull request merged at time.
+	MergedAt *time.Time
+}
+
+// Duration represents a time duration.
+type Duration struct {
+	// InDays is the duration time in days.
+	InDays float64 `json:"inDays"`
+
+	// FormattedIntervalDates is the duration time formatted in interval of dates.
+	FormattedIntervalDates string `json:"formattedIntervalDates"`
 }
 
 // PullRequests are a slice of pull requests.

--- a/domain/metrics/api/api.go
+++ b/domain/metrics/api/api.go
@@ -2,8 +2,8 @@ package api
 
 // PullRequest represents a pull request.
 type PullRequest struct {
-	// Duration is the duration time of the pull request.
-	Duration float64 `json:"duration"`
+	// DurationInDays is the duration time of the pull request in days.
+	DurationInDays float64 `json:"durationInDays"`
 }
 
 // PullRequests are a slice of pull requests.

--- a/domain/metrics/mappers/mappers.go
+++ b/domain/metrics/mappers/mappers.go
@@ -43,6 +43,6 @@ func PullRequestsFromTypeToAPI(pullRequests []*types.PullRequest) api.PullReques
 // PullRequestFromTypeToAPI maps given pull request internal type to pull request API type.
 func PullRequestFromTypeToAPI(pullRequest *types.PullRequest) api.PullRequest {
 	return api.PullRequest{
-		Duration: pullRequest.Duration.Hours() / 24,
+		DurationInDays: pullRequest.Duration.Hours() / 24,
 	}
 }

--- a/domain/metrics/mappers/mappers.go
+++ b/domain/metrics/mappers/mappers.go
@@ -43,6 +43,9 @@ func PullRequestsFromTypeToAPI(pullRequests []*types.PullRequest) api.PullReques
 // PullRequestFromTypeToAPI maps given pull request internal type to pull request API type.
 func PullRequestFromTypeToAPI(pullRequest *types.PullRequest) api.PullRequest {
 	return api.PullRequest{
-		DurationInDays: pullRequest.Duration.Hours() / 24,
+		Duration: api.Duration{
+			InDays:                 pullRequest.Duration.Hours() / 24,
+			FormattedIntervalDates: pullRequest.FormattedIntervalDates(),
+		},
 	}
 }

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -49,7 +49,9 @@ func (s *service) findPullRequests(ctx context.Context, param types.FindPullRequ
 	// Extract pull request metrics.
 	duration := pullRequest.MergedAt.Sub(*pullRequest.CreatedAt)
 	pr := &types.PullRequest{
-		Duration: duration,
+		Duration:  duration,
+		CreatedAt: pullRequest.CreatedAt,
+		MergedAt:  pullRequest.MergedAt,
 	}
 
 	// Create the result.

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/chris-ramon/golang-scaffolding/domain/metrics/types"
@@ -44,6 +45,14 @@ func (s *service) findPullRequests(ctx context.Context, param types.FindPullRequ
 	pullRequest, _, err := client.PullRequests.Get(ctx, param.Owner, param.Repo, param.Number)
 	if err != nil {
 		return nil, err
+	}
+
+	if pullRequest.MergedAt == nil {
+		return nil, fmt.Errorf("unexpected merged at nil value")
+	}
+
+	if pullRequest.CreatedAt == nil {
+		return nil, fmt.Errorf("unexpected created at nil value")
 	}
 
 	// Extract pull request metrics.

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // PullRequest represents an internal pull request.
 type PullRequest struct {
@@ -15,6 +18,17 @@ type PullRequest struct {
 
 	// Repo is the repository name of the pull request.
 	Repo string
+
+	// CreatedAt is the pull request created at time.
+	CreatedAt *time.Time
+
+	// MergedAt is the pull request merged at time.
+	MergedAt *time.Time
+}
+
+// FormattedIntervalDates formats and returns the created at and merged at dates.
+func (pr PullRequest) FormattedIntervalDates() string {
+	return fmt.Sprintf("%s - %s", pr.CreatedAt.String(), pr.MergedAt.String())
 }
 
 // PullRequests are a slice of pull requests.

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -28,6 +28,10 @@ type PullRequest struct {
 
 // FormattedIntervalDates formats and returns the created at and merged at dates.
 func (pr PullRequest) FormattedIntervalDates() string {
+	if pr.CreatedAt == nil || pr.MergedAt == nil {
+		return ""
+	}
+
 	return fmt.Sprintf("%s - %s", pr.CreatedAt.String(), pr.MergedAt.String())
 }
 


### PR DESCRIPTION
##### Details
- `domain/gql`: wires DurationType to PullRequestType.
- `domain/metrics`: wires PullRequest CreatedAt and MergedAt fields.
- `domain/metrics`: syncs Duration type.
- `domain/metrics`: adds PullRequest CreatedAt, MergedAt and Duration type.
- `domain/metrics`: adds PullRequest CreatedAt, MergedAt fields and FormattedIntervalDates method.
- `domain`: replaces PullRequest duration field to durationInDays for clarity.


#### Test Plan
- :heavy_check_mark: Tested that the `pullRequests` field works as expected:

![Screenshot from 2025-05-02 16-35-22](https://github.com/user-attachments/assets/5f3b0203-32d6-47cc-bbbf-330eb19af387)
