### PR TITLE
`domain`: adds `pullRequests` url field.

### DIFF
--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -124,6 +124,10 @@ var MetricsType = graphql.NewObject(graphql.ObjectConfig{
 var PullRequestType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "PullRequestType",
 	Fields: graphql.Fields{
+		"url": &graphql.Field{
+			Description: "The pull request url",
+			Type:        graphql.String,
+		},
 		"duration": &graphql.Field{
 			Description: "The duration of the pull request.",
 			Type:        DurationType,

--- a/domain/metrics/api/api.go
+++ b/domain/metrics/api/api.go
@@ -14,6 +14,9 @@ type PullRequest struct {
 
 	// MergedAt is the pull request merged at time.
 	MergedAt *time.Time
+
+	// URL is the pull request url.
+	URL string
 }
 
 // Duration represents a time duration.

--- a/domain/metrics/github/urls.go
+++ b/domain/metrics/github/urls.go
@@ -43,6 +43,7 @@ func PullRequestFromURL(url string) (*types.PullRequest, error) {
 		Owner:  owner,
 		Repo:   repo,
 		Number: number,
+		URL:    url,
 	}
 
 	return result, nil

--- a/domain/metrics/mappers/mappers.go
+++ b/domain/metrics/mappers/mappers.go
@@ -23,6 +23,7 @@ func PullRequestFromTypeToFindParam(pullRequest types.PullRequest) types.FindPul
 		Number: pullRequest.Number,
 		Owner:  pullRequest.Owner,
 		Repo:   pullRequest.Repo,
+		URL:    pullRequest.URL,
 	}
 
 	return result
@@ -43,6 +44,7 @@ func PullRequestsFromTypeToAPI(pullRequests []*types.PullRequest) api.PullReques
 // PullRequestFromTypeToAPI maps given pull request internal type to pull request API type.
 func PullRequestFromTypeToAPI(pullRequest *types.PullRequest) api.PullRequest {
 	return api.PullRequest{
+		URL: pullRequest.URL,
 		Duration: api.Duration{
 			InDays:                 pullRequest.Duration.Hours() / 24,
 			FormattedIntervalDates: pullRequest.FormattedIntervalDates(),

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -61,6 +61,7 @@ func (s *service) findPullRequests(ctx context.Context, param types.FindPullRequ
 		Duration:  duration,
 		CreatedAt: pullRequest.CreatedAt,
 		MergedAt:  pullRequest.MergedAt,
+		URL:       param.URL,
 	}
 
 	// Create the result.

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -24,6 +24,9 @@ type PullRequest struct {
 
 	// MergedAt is the pull request merged at time.
 	MergedAt *time.Time
+
+	// URL is the pull request url.
+	URL string
 }
 
 // FormattedIntervalDates formats and returns the created at and merged at dates.
@@ -48,6 +51,9 @@ type FindPullRequestParam struct {
 
 	// Repo is the repository name parameter.
 	Repo string
+
+	// URL is the pull request url.
+	URL string
 }
 
 // FindPullRequestsParams are a slice of find pull requests parameters.


### PR DESCRIPTION
##### Details
- `domain/metrics`: wires pull request url field.
- `domain/gql`: wires url to PullRequestType.
- `domain/metrics/mappers`: wires pull request url field.
- `domain/metrics`: wires pull request url field.
- `domain/metrics`: adds PullRequest.URL field.
- `domain/metrics`: adds pull request url field.

#### Test Plan
- :heavy_check_mark: Tested that the `pullRequests` field works as expected:

file:///home/chris/Pictures/Screenshots/Screenshot%20from%202025-05-05%2015-19-05.png