### PR TITLE
`{cache,domain,go.sum,main}`: Adds cache to find pull requests.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,8 +20,8 @@ func (c *Cache) Add(key string, value any) {
 }
 
 func (c *Cache) Get(key string) (any, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.cache.Get(lru.Key(key))
 }
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,16 +1,27 @@
 package cache
 
-import "github.com/golang/groupcache/lru"
+import (
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+)
 
 type Cache struct {
+	// mu guards cache.
+	mu sync.RWMutex
+
 	cache *lru.Cache
 }
 
 func (c *Cache) Add(key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cache.Add(lru.Key(key), value)
 }
 
 func (c *Cache) Get(key string) (any, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.cache.Get(lru.Key(key))
 }
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,8 @@
+package cache
+
+type Cache struct {
+}
+
+func New() *Cache {
+	return &Cache{}
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,8 +1,23 @@
 package cache
 
+import "github.com/golang/groupcache/lru"
+
 type Cache struct {
+	cache lru.Cache
+}
+
+func (c *Cache) Add(key string, value any) {
+	c.cache.Add(lru.Key(key), value)
+}
+
+func (c *Cache) Get(key string) (any, bool) {
+	return c.cache.Get(lru.Key(key))
 }
 
 func New() *Cache {
-	return &Cache{}
+	c := &Cache{
+		cache: lru.Cache{},
+	}
+
+	return c
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,7 @@ package cache
 import "github.com/golang/groupcache/lru"
 
 type Cache struct {
-	cache lru.Cache
+	cache *lru.Cache
 }
 
 func (c *Cache) Add(key string, value any) {
@@ -15,8 +15,11 @@ func (c *Cache) Get(key string) (any, bool) {
 }
 
 func New() *Cache {
+	// Initializes LRU cache with a reasonable 1k as max entries.
+	cache := lru.New(1000)
+
 	c := &Cache{
-		cache: lru.Cache{},
+		cache: cache,
 	}
 
 	return c

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,8 @@ require (
 
 require (
 	github.com/evanw/esbuild v0.12.17 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -28,5 +29,5 @@ require (
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
@@ -538,6 +540,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -1704,6 +1708,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1531,6 +1531,7 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -36,8 +36,6 @@ func main() {
 		log.Println("successfully run migrations")
 	}
 
-	router := http.NewServeMux()
-
 	usersRepo := users.NewRepo(db)
 	usersService := users.NewService(usersRepo)
 	usersHandlers, err := users.NewHandlers(usersService)
@@ -88,6 +86,8 @@ func main() {
 		adminRoutes.All(),
 		usersRoutes.All(),
 	)
+
+	router := http.NewServeMux()
 
 	for _, r := range routes {
 		router.HandleFunc(fmt.Sprintf("%s %s", r.HTTPMethod, r.Path), r.Handler)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 
+	cachePkg "github.com/chris-ramon/golang-scaffolding/cache"
 	"github.com/chris-ramon/golang-scaffolding/config"
 	"github.com/chris-ramon/golang-scaffolding/db"
 	"github.com/chris-ramon/golang-scaffolding/domain/admin"
@@ -35,6 +36,9 @@ func main() {
 	} else {
 		log.Println("successfully run migrations")
 	}
+
+	cache := cachePkg.New()
+	log.Println(cache)
 
 	usersRepo := users.NewRepo(db)
 	usersService := users.NewService(usersRepo)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,8 @@ func main() {
 	}
 
 	cache := cachePkg.New()
-	log.Println(cache)
+	cache.Add("1", 1)
+	log.Println(cache.Get("1"))
 
 	usersRepo := users.NewRepo(db)
 	usersService := users.NewService(usersRepo)

--- a/main.go
+++ b/main.go
@@ -38,8 +38,6 @@ func main() {
 	}
 
 	cache := cachePkg.New()
-	cache.Add("1", 1)
-	log.Println(cache.Get("1"))
 
 	usersRepo := users.NewRepo(db)
 	usersService := users.NewService(usersRepo)
@@ -67,7 +65,7 @@ func main() {
 	}
 
 	HTTPClient := &http.Client{}
-	metricsService, err := metrics.NewService(HTTPClient)
+	metricsService, err := metrics.NewService(cache, HTTPClient)
 	if err != nil {
 		handleErr(err)
 	}


### PR DESCRIPTION
#### Details
- `domain/metrics/service`: wires cache add and improves get related method.
- `main`: wires cache to metrics service.
- `domain/metrics/service`: wires cache pkg.
- `go.sum`: syncs.
- `main`: wires test cache.
- `cache`: wires github.com/golang/groupcache/lru pkg.
- `{go.mod,go.sum}`: adds github.com/golang/groupcache/lru pkg.
- `main`: wire cache pkg.
- `cache`: adds initial pkg.
- `main`: better code ordering.

#### Test Plan

:heavy_check_mark: Tested via `graphql/examples/pullRequests.graphql`.