### PR TITLE
`{domain}`: Pull requests DrawIO improvements.

### DIFF
--- a/domain/gql/types/types.go
+++ b/domain/gql/types/types.go
@@ -428,7 +428,7 @@ var GitHubPullRequestType = graphql.NewObject(graphql.ObjectConfig{
 				}
 
 				// Create export file path
-				exportDir := filepath.Join("assets", fmt.Sprintf("-%s", repo), "exports", "pull_requests")
+				exportDir := filepath.Join("assets", "generated", repo, "exports", "pull_requests")
 				exportPath := filepath.Join(exportDir, "data.txt")
 
 				// Check if file already exists
@@ -450,7 +450,7 @@ var GitHubPullRequestType = graphql.NewObject(graphql.ObjectConfig{
 
 					duration := pr.MergedAt.Sub(*pr.CreatedAt)
 					formattedContributors := pr.Contributors.FormattedContributors(metricTypes.CommasFormatContributorType)
-					
+
 					line := fmt.Sprintf("%d|%s|%s|%s|%s|%s|%s",
 						pr.Number,
 						pr.Title,
@@ -474,4 +474,3 @@ var GitHubPullRequestType = graphql.NewObject(graphql.ObjectConfig{
 		},
 	},
 })
-

--- a/domain/metrics/github/github.go
+++ b/domain/metrics/github/github.go
@@ -100,6 +100,11 @@ type AllPullRequestsNode struct {
 		Name githubv4.String
 	}
 	Participants Participants `graphql:"participants(first: $participantsFirst)"`
+	Author       Author       `graphql:"author"`
+}
+
+type Author struct {
+	Login githubv4.String
 }
 
 // AllPullRequests fetches all merged pull requests from a repository with pagination support.

--- a/domain/metrics/service.go
+++ b/domain/metrics/service.go
@@ -257,7 +257,13 @@ func (s *service) FindAllPullRequests(ctx context.Context, params FindAllPullReq
 		}
 
 		contributors := types.Contributors{}
+		contributors = append(contributors, types.Contributor{
+			Login: string(prNode.Author.Login),
+		})
 		for _, participant := range prNode.Participants.Nodes {
+			if participant.Login == prNode.Author.Login {
+				continue
+			}
 			c := types.Contributor{
 				ProfileURL: string(participant.URL),
 				ID:         string(participant.ID),

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -57,7 +57,7 @@ type Author struct {
 
 // AbbreviatedBody returns the abbreviated pull request's body.
 func (p *PullRequest) AbbreviatedBody() string {
-	bodyWithoutMarkdown := markdown.StripMarkdown(b)
+	bodyWithoutMarkdown := markdown.StripMarkdown(p.Body)
 
 	if len(bodyWithoutMarkdown) <= 150 {
 		return bodyWithoutMarkdown

--- a/domain/metrics/types/types.go
+++ b/domain/metrics/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"github.com/chris-ramon/golang-scaffolding/pkg/markdown"
 	"strings"
 	"time"
 )
@@ -43,14 +44,25 @@ type PullRequest struct {
 
 	// FormattedContributors are the pull request's formatted contributors.
 	FormattedContributors string
+
+	// Author is pull request's author.
+	Author Author
+}
+
+// Author represents the pull request author.
+type Author struct {
+	// Login is the contributor login.
+	Login string
 }
 
 // AbbreviatedBody returns the abbreviated pull request's body.
 func (p *PullRequest) AbbreviatedBody() string {
-	if len(p.Body) < 150 {
-		return p.Body
+	bodyWithoutMarkdown := markdown.StripMarkdown(b)
+
+	if len(bodyWithoutMarkdown) <= 150 {
+		return bodyWithoutMarkdown
 	}
-	return fmt.Sprintf("%s ...", p.Body[:150])
+	return fmt.Sprintf("%s ...", bodyWithoutMarkdown[:150])
 }
 
 // Contributor represents the pull request contributor.


### PR DESCRIPTION
#### Details
- `domain/gql/types`: wires generated dir.
- `domain/metrics/service`: wires author login.
- `domain/metrics/types`: wires pull request body.
- `domain/metrics/types`: adds PullRequest.Author field & AbbreviatedBody improvements.
- `domain/metrics/github`: adds PullRequest.Author field.

#### Test Plan
:heavy_check_mark: Tested that DrawIO files renders as expected:

<img width="2527" height="882" alt="graphql-go-compatibility-standard-definitions" src="https://github.com/user-attachments/assets/3b86cc0c-1daf-483f-85a2-33756c553de8" />


